### PR TITLE
chore: update `.gitattributes` to exclude Yarn support files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,6 @@
 # Auto detect text files and normalize EOL to LF
 * text=auto eol=lf
 
-*.gif filter=lfs diff=lfs merge=lfs -text
-*.jpg filter=lfs diff=lfs merge=lfs -text
-*.pxm filter=lfs diff=lfs merge=lfs -text
-*.png filter=lfs diff=lfs merge=lfs -text
-
-/.yarn/releases/** binary
-/.yarn/plugins/** binary
+*.zip binary
+.pnp* linguist-vendored
+.yarn/** linguist-vendored


### PR DESCRIPTION
Also remove `git-lfs` filters for image types.